### PR TITLE
Improve typing and add tests

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,6 @@
+import rawConfig from '../config.js';
+import type { Config } from './types.js';
+
+// Cast configuration loaded from JavaScript file
+const config: Config = rawConfig as Config;
+export default config;

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,3 +22,37 @@ export interface ModelDefinition {
   params: ModelParam[];
   presets?: Preset[];
 }
+
+export interface KitItem {
+  model: string;
+  id: string;
+}
+
+export interface Kit {
+  name: string;
+  name_ru: string;
+  items: KitItem[];
+}
+
+export interface Config {
+  cache_enabled: boolean;
+  cachePath: string;
+  material: {
+    density: number;
+  };
+  port: number;
+  kits: Kit[];
+}
+
+export interface StlInfo {
+  stlPath: string;
+  image: string;
+  volume: number;
+  weight: number;
+  box: any;
+}
+
+export interface KitArchive {
+  path: string;
+  filename: string;
+}

--- a/test/getFrontConfig.test.js
+++ b/test/getFrontConfig.test.js
@@ -1,0 +1,17 @@
+import { strict as assert } from 'assert';
+import { getFrontConfig } from '../dist/index.js';
+
+describe('getFrontConfig', () => {
+  it('returns model configs without generator', () => {
+    const conf = getFrontConfig();
+    assert.ok(Array.isArray(conf.models));
+    assert.ok(conf.models.length > 0);
+    assert.ok(!('generator' in conf.models[0]));
+  });
+
+  it('includes kits from config', () => {
+    const conf = getFrontConfig();
+    assert.ok(Array.isArray(conf.kits));
+  });
+});
+

--- a/test/isParamsValid.test.js
+++ b/test/isParamsValid.test.js
@@ -1,0 +1,16 @@
+import { strict as assert } from 'assert';
+import { fillParamsDefault, isParamsValid } from '../dist/index.js';
+
+describe('isParamsValid', () => {
+  it('returns true when all params provided', () => {
+    const params = fillParamsDefault({ model: 'cap', wall: 1 });
+    assert.ok(isParamsValid(params));
+  });
+
+  it('returns false when a param is empty', () => {
+    const params = fillParamsDefault({ model: 'cap', wall: 1 });
+    params.height = '';
+    assert.equal(isParamsValid(params), false);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add typed wrapper for configuration
- extend type definitions for kits and STL info
- refactor `index.ts` with stronger typing
- expose `isParamsValid` and `getFrontConfig`
- test `isParamsValid` and `getFrontConfig`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bc841ba14832cb7efa1dfbe0b1072